### PR TITLE
[REFACTOR] 북마크 리팩토링 및 일부 기능 추가

### DIFF
--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +35,7 @@ public class BookmarkApiController {
 	private final BookmarkService bookmarkService;
 
 	@GetMapping("/view/{id}")
-	@Operation(summary = "게시글 북마크 조회", description = "게시글에 대해 회원이 등록해둔 북마크 목록을 조회합니다.")
+	@Operation(summary = "게시글 북마크 조회", description = "게시글에 대해 회원이 등록해 둔 북마크 목록을 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
@@ -49,21 +50,40 @@ public class BookmarkApiController {
 		);
 	}
 
-	@PostMapping("/update")
-	@Operation(summary = "북마크 수정", description = "회원이 북마크를 수정합니다.")
+	@PostMapping("/create/{id}")
+	@Operation(summary = "북마크 생성", description = "회원이 북마크를 생성합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
-	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkUpdateResponse>> updateBookmark(
-		Authentication authentication, @RequestBody BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto
+	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkCreateResponse>> createBookmark(
+		Authentication authentication,
+		@PathVariable Long id,
+		@RequestBody BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto
 	) {
 
 		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_UPDATE_SUCCESS, bookmarkService.updateBookmark(authentication.getName(), bookmarkRequestDto)
+			BOOKMARK_CREATE_SUCCESS, bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, id)
 		);
+	}
 
+	@PutMapping("/update/{id}")
+	@Operation(summary = "북마크 메모 수정", description = "회원이 북마크 메모를 수정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
+		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
+	})
+	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkMyListResponse>> updateBookmark(
+		Authentication authentication,
+		@PathVariable Long id,
+		@RequestBody BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto
+	) {
+
+		return ResponseEntityFactory.toResponseEntity(
+			BOOKMARK_UPDATE_SUCCESS, bookmarkService.updateBookmark(authentication.getName(), bookmarkRequestDto, id)
+		);
 	}
 
 }

--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,11 +65,12 @@ public class BookmarkApiController {
 	) {
 
 		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_CREATE_SUCCESS, bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, contentId)
+			BOOKMARK_CREATE_SUCCESS,
+			bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, contentId)
 		);
 	}
 
-	@PutMapping("/update/{id}")
+	@PutMapping("/update/{contentId}")
 	@Operation(summary = "북마크 메모 수정", description = "회원이 북마크 메모를 수정합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
@@ -76,13 +78,29 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
 	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkMyListResponse>> updateBookmark(
-		Authentication authentication,
-		@PathVariable Long id,
+		@PathVariable Long contentId,
 		@RequestBody BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto
 	) {
 
 		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_UPDATE_SUCCESS, bookmarkService.updateBookmark(authentication.getName(), bookmarkRequestDto, id)
+			BOOKMARK_UPDATE_SUCCESS, bookmarkService.updateBookmark(bookmarkRequestDto, contentId)
+		);
+	}
+
+	@DeleteMapping("/delete/{bookmarkId}")
+	@Operation(summary = "북마크 삭제", description = "회원이 북마크를 삭제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
+		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
+	})
+	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkDeleteResponse>> deleteBookmark(
+		Authentication authentication,
+		@PathVariable Long bookmarkId
+	) {
+
+		return ResponseEntityFactory.toResponseEntity(
+			BOOKMARK_DELETE_SUCCESS, bookmarkService.deleteBookmark(authentication.getName(), bookmarkId)
 		);
 	}
 

--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class BookmarkApiController {
 	private final BookmarkService bookmarkService;
 
-	@GetMapping("/view/{id}")
+	@GetMapping("/view/{contentId}")
 	@Operation(summary = "게시글 북마크 조회", description = "게시글에 대해 회원이 등록해 둔 북마크 목록을 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
@@ -43,14 +43,14 @@ public class BookmarkApiController {
 	})
 	public ResponseEntity<ApiCustomResponse<List<BookmarkResponseDto.BookmarkMyListResponse>>> getBookmarks(
 		Authentication authentication,
-		@PathVariable Long id
+		@PathVariable Long contentId
 	) {
 		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_VIEW_SUCCESS, bookmarkService.getBookmarks(authentication.getName(), id)
+			BOOKMARK_VIEW_SUCCESS, bookmarkService.getBookmarks(authentication.getName(), contentId)
 		);
 	}
 
-	@PostMapping("/create/{id}")
+	@PostMapping("/create/{contentId}")
 	@Operation(summary = "북마크 생성", description = "회원이 북마크를 생성합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
@@ -59,12 +59,12 @@ public class BookmarkApiController {
 	})
 	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkCreateResponse>> createBookmark(
 		Authentication authentication,
-		@PathVariable Long id,
+		@PathVariable Long contentId,
 		@RequestBody BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto
 	) {
 
 		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_CREATE_SUCCESS, bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, id)
+			BOOKMARK_CREATE_SUCCESS, bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, contentId)
 		);
 	}
 

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
@@ -1,5 +1,7 @@
 package com.echall.platform.bookmark.domain.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class BookmarkRequestDto {
 	public record BookmarkCreateRequest(
 		Long sentenceIndex,
@@ -9,6 +11,7 @@ public class BookmarkRequestDto {
 
 	public record BookmarkUpdateRequest(
 		Long bookmarkId,
+		@NotBlank
 		String description
 	) {
 	}

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
@@ -1,6 +1,5 @@
 package com.echall.platform.bookmark.domain.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public class BookmarkRequestDto {
@@ -13,8 +12,8 @@ public class BookmarkRequestDto {
 	public record BookmarkUpdateRequest(
 		@NotNull
 		Long bookmarkId,
-		@NotBlank
 		String description
 	) {
 	}
+
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
@@ -1,6 +1,7 @@
 package com.echall.platform.bookmark.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class BookmarkRequestDto {
 	public record BookmarkCreateRequest(
@@ -10,6 +11,7 @@ public class BookmarkRequestDto {
 	}
 
 	public record BookmarkUpdateRequest(
+		@NotNull
 		Long bookmarkId,
 		@NotBlank
 		String description

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
@@ -1,15 +1,15 @@
 package com.echall.platform.bookmark.domain.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-
 public class BookmarkRequestDto {
-	public record BookmarkUpdateRequest(
-		@Schema(description = "컨텐츠 인덱스(ID)")
-		Long scriptIndex,
-		@Schema(description = "문장 인덱스")
+	public record BookmarkCreateRequest(
 		Long sentenceIndex,
-		@Schema(description = "단어 인덱스")
 		Long wordIndex
+	) {
+	}
+
+	public record BookmarkUpdateRequest(
+		Long bookmarkId,
+		String description
 	) {
 	}
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
@@ -34,5 +34,9 @@ public class BookmarkResponseDto {
 			);
 		}
 	}
+	public record BookmarkDeleteResponse(
+		Long bookmarkId
+	){
+	}
 
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
@@ -4,12 +4,30 @@ import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 
 public class BookmarkResponseDto {
 	public record BookmarkMyListResponse(
+		Long bookmarkId,
+		Long sentenceIndex,
+		Long wordIndex,
+		String description
+	) {
+		public static BookmarkMyListResponse of(BookmarkEntity bookmark) {
+			return new BookmarkMyListResponse(
+				bookmark.getId(),
+				bookmark.getSentenceIndex(),
+				bookmark.getWordIndex(),
+				bookmark.getDescription()
+			);
+		}
+	}
+
+	public record BookmarkCreateResponse(
+		Long bookmarkId,
 		Long scriptIndex,
 		Long sentenceIndex,
 		Long wordIndex
 	) {
-		public static BookmarkMyListResponse of(BookmarkEntity bookmark){
-			return new BookmarkMyListResponse(
+		public static BookmarkCreateResponse of(BookmarkEntity bookmark) {
+			return new BookmarkCreateResponse(
+				bookmark.getId(),
 				bookmark.getScriptIndex(),
 				bookmark.getSentenceIndex(),
 				bookmark.getWordIndex()
@@ -17,9 +35,4 @@ public class BookmarkResponseDto {
 		}
 	}
 
-	public record BookmarkUpdateResponse(
-		Long contentId,
-		Long bookmarkId
-	) {
-	}
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -50,12 +49,7 @@ public class BookmarkEntity extends BaseEntity {
 		this.description = description;
 	}
 
-	@Transactional
-	public boolean updateDescription(BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto) {
-		if (this.description != null && this.description.equals(bookmarkRequestDto.description())) {
-			return false;
-		}
+	public void updateDescription(BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto) {
 		this.description = bookmarkRequestDto.description();
-		return true;
 	}
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -49,8 +49,7 @@ public class BookmarkEntity extends BaseEntity {
 		this.scriptIndex = scriptIndex;
 		this.sentenceIndex = sentenceIndex;
 		this.wordIndex = wordIndex;
-		this.description = description;
-	}
+		this.description = description;	}
 
 	public void updateDescription(BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto) {
 		this.description = bookmarkRequestDto.description();

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -3,6 +3,7 @@ package com.echall.platform.bookmark.domain.entity;
 import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.user.domain.entity.BaseEntity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,13 +28,16 @@ public class BookmarkEntity extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@NotNull
+	@Column(nullable = false, columnDefinition = "varchar(255)")
 	private Long scriptIndex;
 
+	@Column(columnDefinition = "varchar(255)")
 	private Long sentenceIndex;
 
+	@Column(columnDefinition = "varchar(255)")
 	private Long wordIndex;
 
+	@Column(columnDefinition = "varchar(255)")
 	private String description;
 
 	@Builder

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -1,5 +1,6 @@
 package com.echall.platform.bookmark.domain.entity;
 
+import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.user.domain.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
@@ -7,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,13 +34,24 @@ public class BookmarkEntity extends BaseEntity {
 
 	private Long wordIndex;
 
+	private String description;
+
 	@Builder
 	public BookmarkEntity(
-		@NotNull Long scriptIndex, Long sentenceIndex, Long wordIndex
+		@NotNull Long scriptIndex, Long sentenceIndex, Long wordIndex, String description
 	) {
 		this.scriptIndex = scriptIndex;
 		this.sentenceIndex = sentenceIndex;
 		this.wordIndex = wordIndex;
+		this.description = description;
 	}
 
+	@Transactional
+	public boolean updateDescription(BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto) {
+		if (this.description != null && this.description.equals(bookmarkRequestDto.description())) {
+			return false;
+		}
+		this.description = bookmarkRequestDto.description();
+		return true;
+	}
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -30,13 +30,13 @@ public class BookmarkEntity extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, columnDefinition = "varchar(255)")
+	@Column(nullable = false, columnDefinition = "bigint")
 	private Long scriptIndex;
 
-	@Column(columnDefinition = "varchar(255)")
+	@Column(columnDefinition = "bigint")
 	private Long sentenceIndex;
 
-	@Column(columnDefinition = "varchar(255)")
+	@Column(columnDefinition = "bigint")
 	private Long wordIndex;
 
 	@Column(columnDefinition = "varchar(255)")

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -2,12 +2,15 @@ package com.echall.platform.bookmark.domain.entity;
 
 import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.user.domain.entity.BaseEntity;
+import com.echall.platform.user.domain.entity.UserEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;

--- a/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 
 public interface BookmarkRepository extends JpaRepository<BookmarkEntity, Long> {
+
+	boolean existsBySentenceIndexOrWordIndex(Long sentenceIndex, Long wordIndex);
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
@@ -6,6 +6,11 @@ import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 
 public interface BookmarkService {
-	List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String name, Long contentId);
-	BookmarkResponseDto.BookmarkUpdateResponse updateBookmark(String name, BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto);
+	List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String email, Long contentId);
+	BookmarkResponseDto.BookmarkMyListResponse updateBookmark(
+		String email, BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
+	);
+	BookmarkResponseDto.BookmarkCreateResponse createBookmark(
+		String email, BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, Long contentId
+	);
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
@@ -7,10 +7,16 @@ import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 
 public interface BookmarkService {
 	List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String email, Long contentId);
+
 	BookmarkResponseDto.BookmarkMyListResponse updateBookmark(
-		String email, BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
+		BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
 	);
+
 	BookmarkResponseDto.BookmarkCreateResponse createBookmark(
 		String email, BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, Long contentId
+	);
+
+	BookmarkResponseDto.BookmarkDeleteResponse deleteBookmark(
+		String email, Long bookmarkId
 	);
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -90,7 +90,8 @@ public class BookmarkServiceImpl implements BookmarkService {
 	public BookmarkResponseDto.BookmarkDeleteResponse deleteBookmark(
 		String email, Long bookmarkId
 	) {
-		UserEntity user = userRepository.findUserWithBookmarks(bookmarkId);
+		UserEntity user = userRepository.findUserWithBookmarks(bookmarkId)
+			.orElseThrow(() -> new CommonException(USER_NOT_FOUND));
 		BookmarkEntity bookmark = user.getBookmarks()
 			.stream()
 			.filter(bookmarkEntity -> bookmarkEntity.getId().equals(bookmarkId))

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -81,9 +81,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 		BookmarkEntity bookmark = bookmarkRepository.findById(bookmarkRequestDto.bookmarkId())
 			.orElseThrow(() -> new CommonException(BOOKMARK_NOT_FOUND));
 
-		if (!bookmark.updateDescription(bookmarkRequestDto)) {
-			throw new CommonException(BOOKMARK_DESCRIPTION_SAME);
-		}
+		bookmark.updateDescription(bookmarkRequestDto);
 
 		return BookmarkResponseDto.BookmarkMyListResponse.of(bookmark);
 	}

--- a/src/main/java/com/echall/platform/content/controller/ContentPublicController.java
+++ b/src/main/java/com/echall/platform/content/controller/ContentPublicController.java
@@ -2,6 +2,8 @@ package com.echall.platform.content.controller;
 
 import static com.echall.platform.message.response.ContentResponseCode.*;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -10,10 +12,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.echall.platform.content.domain.dto.ContentPageResponse;
 import com.echall.platform.content.domain.dto.ContentResponseDto;
+import com.echall.platform.content.domain.enums.ContentType;
 import com.echall.platform.content.domain.enums.SearchCondition;
 import com.echall.platform.content.service.ContentService;
 import com.echall.platform.message.ApiCustomResponse;
@@ -56,13 +60,53 @@ public class ContentPublicController {
 		@Parameter(name = "size", description = "페이지당 데이터 수", in = ParameterIn.QUERY, schema = @Schema(type = "integer", defaultValue = "10")),
 		@Parameter(name = "sort", description = "정렬 기준 (예: createdAt,desc)", in = ParameterIn.QUERY, schema = @Schema(type = "string"))
 	})
-	public ResponseEntity<ApiCustomResponse<Page<ContentResponseDto.ContentViewResponseDto>>> getPreviewContents(
+	public ResponseEntity<ApiCustomResponse<Page<ContentResponseDto.ContentViewResponseDto>>> getContents(
 		@Parameter(hidden = true) @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-		SearchCondition searchCondition) {
+		SearchCondition searchCondition
+	) {
 		Page<ContentResponseDto.ContentViewResponseDto> pageContentList
 			= contentService.getAllContents(pageable, searchCondition);
 
 		return ResponseEntityFactory.toResponseEntity(CONTENT_VIEW_SUCCESS, pageContentList);
+	}
+
+	@GetMapping("/preview/leading")
+	@Operation(summary = "리딩 컨텐츠 프리뷰 조회", description = "리딩 컨텐츠 프리뷰 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = {
+			@Content(mediaType = "application/json", schema = @Schema(implementation = ContentPageResponse.class))
+		}),
+		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
+	})
+	public ResponseEntity<ApiCustomResponse<List<ContentResponseDto.ContentPreviewResponseDto>>>
+	getPreviewLeadingContents(
+		@RequestParam(defaultValue = "hits") String sortBy,
+		@RequestParam(defaultValue = "8") int num
+	) {
+		List<ContentResponseDto.ContentPreviewResponseDto> leadingPreview
+			= contentService.getPreviewContents(ContentType.LEADING, sortBy, num);
+		return ResponseEntityFactory.toResponseEntity(CONTENT_VIEW_SUCCESS, leadingPreview);
+	}
+
+	@GetMapping("/preview/listening")
+	@Operation(summary = "리스닝 컨텐츠 프리뷰 조회", description = "리스닝 컨텐츠 프리뷰 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = {
+			@Content(mediaType = "application/json", schema = @Schema(implementation = ContentPageResponse.class))
+		}),
+		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
+	})
+	public ResponseEntity<ApiCustomResponse<List<ContentResponseDto.ContentPreviewResponseDto>>>
+	getPreviewListeningContents(
+		@RequestParam(defaultValue = "hits") String sortBy,
+		@RequestParam(defaultValue = "8") int num
+	) {
+		List<ContentResponseDto.ContentPreviewResponseDto> listeningPreviews
+			= contentService.getPreviewContents(ContentType.LISTENING, sortBy, num);
+
+		return ResponseEntityFactory.toResponseEntity(CONTENT_VIEW_SUCCESS, listeningPreviews);
 	}
 
 	/**

--- a/src/main/java/com/echall/platform/content/domain/dto/ContentResponseDto.java
+++ b/src/main/java/com/echall/platform/content/domain/dto/ContentResponseDto.java
@@ -9,6 +9,7 @@ import com.echall.platform.content.domain.enums.ContentType;
 public class ContentResponseDto {
 
 	public record ContentViewResponseDto(
+		Long contentId,
 		String scriptId,
 		String title,
 		String enScripts,
@@ -42,5 +43,16 @@ public class ContentResponseDto {
 		List<Script> scriptList
 	) {
 
+	}
+
+	public record ContentPreviewResponseDto(
+		Long contentId,
+		String title,
+		String thumbnailUrl,
+		ContentType contentType,
+		String preScripts,
+		String category,
+		int hits
+	) {
 	}
 }

--- a/src/main/java/com/echall/platform/content/domain/entity/ContentEntity.java
+++ b/src/main/java/com/echall/platform/content/domain/entity/ContentEntity.java
@@ -80,7 +80,6 @@ public class ContentEntity extends BaseEntity {
 		);
 	}
 
-	@Transactional
 	public void update(ContentRequestDto.ContentUpdateRequestDto dto) {
 		this.url = dto.url();
 		this.title = dto.title();
@@ -93,7 +92,6 @@ public class ContentEntity extends BaseEntity {
 			, 255);
 	}
 
-	@Transactional
 	public void updateStatus(ContentStatus contentStatus) {
 		this.contentStatus = contentStatus == null ? ContentStatus.ACTIVATED : contentStatus;
 	}

--- a/src/main/java/com/echall/platform/content/domain/entity/ContentEntity.java
+++ b/src/main/java/com/echall/platform/content/domain/entity/ContentEntity.java
@@ -15,6 +15,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -42,6 +43,9 @@ public class ContentEntity extends BaseEntity {
 
 	private String category;
 
+	@Column(columnDefinition = "integer default 0")
+	private int hits;
+
 	private String thumbnailUrl;
 
 	@Size(max = 255)
@@ -61,7 +65,6 @@ public class ContentEntity extends BaseEntity {
 		ContentType contentType, String mongoContentId,
 		List<Script> preScripts
 	) {
-
 		this.url = url;
 		this.title = title;
 		this.category = category;
@@ -77,6 +80,7 @@ public class ContentEntity extends BaseEntity {
 		);
 	}
 
+	@Transactional
 	public void update(ContentRequestDto.ContentUpdateRequestDto dto) {
 		this.url = dto.url();
 		this.title = dto.title();
@@ -89,6 +93,7 @@ public class ContentEntity extends BaseEntity {
 			, 255);
 	}
 
+	@Transactional
 	public void updateStatus(ContentStatus contentStatus) {
 		this.contentStatus = contentStatus == null ? ContentStatus.ACTIVATED : contentStatus;
 	}

--- a/src/main/java/com/echall/platform/content/domain/enums/ContentStatus.java
+++ b/src/main/java/com/echall/platform/content/domain/enums/ContentStatus.java
@@ -1,8 +1,8 @@
 package com.echall.platform.content.domain.enums;
 
 public enum ContentStatus {
-	//활성화된 상태
+	// 활성화된 상태, 문제 만들어 진 후
 	ACTIVATED,
-	//비활성화된 상태
+	// 비활성화된 상태, 문제 만들어 지기 전
 	DEACTIVATED
 }

--- a/src/main/java/com/echall/platform/content/domain/enums/SearchCondition.java
+++ b/src/main/java/com/echall/platform/content/domain/enums/SearchCondition.java
@@ -2,9 +2,9 @@ package com.echall.platform.content.domain.enums;
 
 import java.util.List;
 
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class SearchCondition {
 	private List<String> script;
 	private String title;

--- a/src/main/java/com/echall/platform/content/repository/ContentRepository.java
+++ b/src/main/java/com/echall/platform/content/repository/ContentRepository.java
@@ -1,5 +1,7 @@
 package com.echall.platform.content.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.echall.platform.content.domain.entity.ContentEntity;

--- a/src/main/java/com/echall/platform/content/repository/ContentRepository.java
+++ b/src/main/java/com/echall/platform/content/repository/ContentRepository.java
@@ -1,7 +1,5 @@
 package com.echall.platform.content.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.echall.platform.content.domain.entity.ContentEntity;

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
@@ -1,14 +1,23 @@
 package com.echall.platform.content.repository.custom;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.echall.platform.content.domain.dto.ContentResponseDto;
+import com.echall.platform.content.domain.enums.ContentType;
 import com.echall.platform.content.domain.enums.SearchCondition;
 
 public interface ContentRepositoryCustom {
 	Page<ContentResponseDto.ContentViewResponseDto> search(
 		Pageable pageable, SearchCondition searchCondition
 	);
+
+	List<ContentResponseDto.ContentPreviewResponseDto> getPreviewContents(
+		ContentType contentType, String sortBy, int num
+	);
+
+	int updateHit(Long contentId);
 
 }

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.echall.platform.content.repository.custom;
 import static com.echall.platform.content.domain.entity.QContentEntity.*;
 import static com.echall.platform.message.error.code.UserErrorCode.*;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -12,14 +14,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.echall.platform.content.domain.dto.ContentResponseDto;
 import com.echall.platform.content.domain.entity.ContentDocument;
 import com.echall.platform.content.domain.entity.ContentEntity;
 import com.echall.platform.content.domain.entity.Script;
+import com.echall.platform.content.domain.enums.ContentType;
 import com.echall.platform.content.domain.enums.SearchCondition;
 import com.echall.platform.content.repository.ContentScriptRepository;
 import com.echall.platform.message.error.exception.CommonException;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQuery;
 
 public class ContentRepositoryImpl extends QuerydslRepositorySupport implements ContentRepositoryCustom {
@@ -32,6 +40,7 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Page<ContentResponseDto.ContentViewResponseDto> search(Pageable pageable, SearchCondition searchCondition) {
 
 		// Step 1: Fetch relevant MongoDB data
@@ -60,7 +69,7 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 			.map(entity -> {
 				// Fetch Mysql Entity
 				String scriptSentences = entity.getPreScripts();
-				if (!searchCondition.getScript().isEmpty() || !searchCondition.getTitle().isBlank()) {
+				if (searchCondition.getScript() != null || searchCondition.getTitle() != null) {
 					// Fetch MongoDB document
 					scriptSentences
 						= contentScriptRepository.findContentDocumentById(new ObjectId(entity.getMongoContentId()))
@@ -75,10 +84,11 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 
 				// Create DTO with both JPA and MongoDB data
 				return new ContentResponseDto.ContentViewResponseDto(
+					entity.getId(),
 					entity.getMongoContentId(),
 					entity.getTitle(),
 					scriptSentences,
-					scriptSentences,    // TODO: 번역 필요
+					scriptSentences,    // TODO: 번역 해야 하면 변경
 					entity.getContentType(),
 					entity.getCreatedAt(),
 					entity.getUpdatedAt()
@@ -89,4 +99,52 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 		// Step 4: Return paginated result
 		return new PageImpl<>(responseDtos, pageable, jpaQuery.fetchCount());
 	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<ContentResponseDto.ContentPreviewResponseDto> getPreviewContents(
+		ContentType contentType, String sortBy, int num
+	) {
+		Field field;
+		try {
+			field = contentEntity.getClass().getField(sortBy);
+		} catch (NoSuchFieldException e) {
+			throw new RuntimeException(e);
+		}
+
+		Path<?> path = Expressions.path(field.getType(), contentEntity, field.getName());
+
+		List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+		orderSpecifiers.add(new OrderSpecifier(Order.DESC, path));
+
+		List<ContentEntity> contents = from(contentEntity)
+			.select(contentEntity)
+			.where(contentEntity.contentType.eq(contentType))
+			.orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+			.limit(num)
+			.fetch();
+
+		return contents.stream()
+			.map(content -> new ContentResponseDto.ContentPreviewResponseDto(
+				content.getId(),
+				content.getTitle(),
+				content.getThumbnailUrl(),
+				content.getContentType(),
+				content.getPreScripts(),
+				content.getCategory(),
+				content.getHits()
+			)).toList();
+	}
+
+	@Override
+	@Transactional
+	public int updateHit(Long contentId) {
+		return Math.toIntExact(
+			update(contentEntity)
+				.set(contentEntity.hits, contentEntity.hits.add(1))
+				.where(contentEntity.id.eq(contentId))
+				.execute()
+		);
+	}
+
 }

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.echall.platform.content.repository.custom;
 
 import static com.echall.platform.content.domain.entity.QContentEntity.*;
+import static com.echall.platform.message.error.code.ContentErrorCode.*;
 import static com.echall.platform.message.error.code.UserErrorCode.*;
 
 import java.lang.reflect.Field;
@@ -109,7 +110,7 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 		try {
 			field = contentEntity.getClass().getField(sortBy);
 		} catch (NoSuchFieldException e) {
-			throw new RuntimeException(e);
+			throw new CommonException(CONTENT_SORT_COL_NOT_FOUND);
 		}
 
 		Path<?> path = Expressions.path(field.getType(), contentEntity, field.getName());

--- a/src/main/java/com/echall/platform/content/service/ContentService.java
+++ b/src/main/java/com/echall/platform/content/service/ContentService.java
@@ -1,11 +1,14 @@
 package com.echall.platform.content.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 
 import com.echall.platform.content.domain.dto.ContentRequestDto;
 import com.echall.platform.content.domain.dto.ContentResponseDto;
+import com.echall.platform.content.domain.enums.ContentType;
 import com.echall.platform.content.domain.enums.SearchCondition;
 
 public interface ContentService {
@@ -14,12 +17,18 @@ public interface ContentService {
 	ContentResponseDto.ContentDetailResponseDto getScriptsOfContent(Long id);
 
 	ContentResponseDto.ContentCreateResponseDto createContent(
-		Authentication authentication, ContentRequestDto.ContentCreateRequestDto contentCreateRequestDto)
-		throws Exception; //새로운 컨텐츠 생성
+		Authentication authentication, ContentRequestDto.ContentCreateRequestDto contentCreateRequestDto
+	) throws Exception;
 
-	ContentResponseDto.ContentUpdateResponseDto updateContent(Long id,
-		ContentRequestDto.ContentUpdateRequestDto contentUpdateRequest);
+	ContentResponseDto.ContentUpdateResponseDto updateContent(
+		Long id,
+		ContentRequestDto.ContentUpdateRequestDto contentUpdateRequest
+	);
 
 	ContentResponseDto.ContentUpdateResponseDto deactivateContent(Long id);
+
+	List<ContentResponseDto.ContentPreviewResponseDto> getPreviewContents(
+		ContentType contentType, String sortBy, int num
+	);
 
 }

--- a/src/main/java/com/echall/platform/message/error/code/BookmarkErrorCode.java
+++ b/src/main/java/com/echall/platform/message/error/code/BookmarkErrorCode.java
@@ -1,0 +1,43 @@
+package com.echall.platform.message.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.echall.platform.message.status.BookmarkServiceStatus;
+import com.echall.platform.message.status.ServiceStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BookmarkErrorCode implements ErrorCode {
+	BOOKMARK_NOT_FOUND(
+		HttpStatus.NOT_FOUND, BookmarkServiceStatus.BOOKMARK_NOT_FOUND, "등록된 북마크가 없습니다."
+	),
+	BOOKMARK_DESCRIPTION_SAME(
+		HttpStatus.BAD_REQUEST, BookmarkServiceStatus.BOOKMARK_DESCRIPTION_SAME, "북마크 설명이 기존과 동일합니다."
+	),
+	BOOKMARK_ALREADY_EXISTS(
+		HttpStatus.BAD_REQUEST, BookmarkServiceStatus.BOOKMARK_ALREADY_EXISTS, "이미 존재하는 북마크입니다."
+	),
+	BOOKMARK_WORD_NEED_SENTENCE(
+		HttpStatus.BAD_REQUEST, BookmarkServiceStatus.BOOKMARK_WORD_NEED_SENTENCE,
+		"단어 북마크를 지정하려면 문장 인덱스가 필요합니다.");
+
+	private final HttpStatus httpStatus;
+	private final ServiceStatus serviceStatus;
+	private final String message;
+
+	@Override
+	public HttpStatus getStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getCode() {
+		return serviceStatus.getServiceStatus();
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/echall/platform/message/error/code/ContentErrorCode.java
+++ b/src/main/java/com/echall/platform/message/error/code/ContentErrorCode.java
@@ -9,9 +9,11 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ContentErrorCode implements ErrorCode {
-	CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, ContentServiceStatus.CONTENT_NOT_FOUND, "해당 컨텐츠 존재하지 않음")
+	CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, ContentServiceStatus.CONTENT_NOT_FOUND, "해당 컨텐츠 존재하지 않음"),
 
-	;
+	CONTENT_SORT_COL_NOT_FOUND(
+		HttpStatus.NOT_FOUND, ContentServiceStatus.CONTENT_SORT_COL_NOT_FOUND, "컨텐츠 정렬 조건 존재하지 않음"
+	);
 
 	private final HttpStatus httpStatus;
 	private final ServiceStatus serviceStatus;

--- a/src/main/java/com/echall/platform/message/response/BookmarkResponseCode.java
+++ b/src/main/java/com/echall/platform/message/response/BookmarkResponseCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum BookmarkResponseCode implements ResponseCode {
 	BOOKMARK_VIEW_SUCCESS(HttpStatus.OK, BookmarkServiceStatus.BOOKMARK_VIEW_SUCCESS, "북마크 조회 성공"),
 	BOOKMARK_UPDATE_SUCCESS(HttpStatus.OK, BookmarkServiceStatus.BOOKMARK_UPDATE_SUCCESS, "북마크 설명 수정 성공"),
-	BOOKMARK_CREATE_SUCCESS(HttpStatus.CREATED, BookmarkServiceStatus.BOOKMARK_CREATE_SUCCESS, "북마크 생성 성공")
+	BOOKMARK_CREATE_SUCCESS(HttpStatus.CREATED, BookmarkServiceStatus.BOOKMARK_CREATE_SUCCESS, "북마크 생성 성공"),
+	BOOKMARK_DELETE_SUCCESS(HttpStatus.ACCEPTED, BookmarkServiceStatus.BOOKMARK_DELETE_SUCCESS, "북마크 삭제 성공")
 	;
 
 	private final HttpStatus code;

--- a/src/main/java/com/echall/platform/message/response/BookmarkResponseCode.java
+++ b/src/main/java/com/echall/platform/message/response/BookmarkResponseCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BookmarkResponseCode implements ResponseCode {
 	BOOKMARK_VIEW_SUCCESS(HttpStatus.OK, BookmarkServiceStatus.BOOKMARK_VIEW_SUCCESS, "북마크 조회 성공"),
-	BOOKMARK_UPDATE_SUCCESS(HttpStatus.OK, BookmarkServiceStatus.BOOKMARK_UPDATE_SUCCESS, "북마크 수정 성공")
+	BOOKMARK_UPDATE_SUCCESS(HttpStatus.OK, BookmarkServiceStatus.BOOKMARK_UPDATE_SUCCESS, "북마크 설명 수정 성공"),
+	BOOKMARK_CREATE_SUCCESS(HttpStatus.CREATED, BookmarkServiceStatus.BOOKMARK_CREATE_SUCCESS, "북마크 생성 성공")
 	;
 
 	private final HttpStatus code;

--- a/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
+++ b/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
@@ -8,6 +8,7 @@ public enum BookmarkServiceStatus implements ServiceStatus {
 	BOOKMARK_VIEW_SUCCESS("U-B-001"),
 	BOOKMARK_UPDATE_SUCCESS("U-B-002"),
 	BOOKMARK_CREATE_SUCCESS("U-B-003"),
+	BOOKMARK_DELETE_SUCCESS("U-B-004"),
 
 	// failure,
 	BOOKMARK_NOT_FOUND("U-B-901"),

--- a/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
+++ b/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
@@ -7,11 +7,15 @@ public enum BookmarkServiceStatus implements ServiceStatus {
 	// success
 	BOOKMARK_VIEW_SUCCESS("U-B-001"),
 	BOOKMARK_UPDATE_SUCCESS("U-B-002"),
+	BOOKMARK_CREATE_SUCCESS("U-B-003"),
 
 	// failure,
-	BOOKMARK_VIEW_FAILURE("U-B-901")
-
+	BOOKMARK_NOT_FOUND("U-B-901"),
+	BOOKMARK_DESCRIPTION_SAME("U-B-902"),
+	BOOKMARK_ALREADY_EXISTS("U-B-903"),
+	BOOKMARK_WORD_NEED_SENTENCE("U-B-904")
 	;
+
 	private final String code;
 
 	@Override

--- a/src/main/java/com/echall/platform/message/status/ContentServiceStatus.java
+++ b/src/main/java/com/echall/platform/message/status/ContentServiceStatus.java
@@ -10,7 +10,8 @@ public enum ContentServiceStatus implements ServiceStatus {
 	CONTENT_MODIFY_SUCCESS("U-C-003"),
 	CONTENT_DEACTIVATE_SUCCESS("U-C-004"),
 	// error
-	CONTENT_NOT_FOUND("U-C-901")
+	CONTENT_NOT_FOUND("U-C-901"),
+	CONTENT_SORT_COL_NOT_FOUND("U-C-902")
 	;
 
 	private final String code;

--- a/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
@@ -1,25 +1,35 @@
 package com.echall.platform.user.domain.entity;
 
-import static com.echall.platform.message.error.code.BookmarkErrorCode.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.DynamicUpdate;
 
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
-import com.echall.platform.message.error.exception.CommonException;
 import com.echall.platform.oauth2.domain.info.OAuth2UserPrincipal;
 import com.echall.platform.user.domain.dto.UserRequestDto;
 import com.echall.platform.user.domain.enums.Gender;
 import com.echall.platform.user.domain.enums.Role;
 import com.echall.platform.user.domain.enums.UserStatus;
 import com.echall.platform.util.RandomNicknameGenerator;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicUpdate;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -68,7 +78,7 @@ public class UserEntity extends BaseEntity {
 	private String providerId;
 
 	@OneToMany
-	@JoinColumn(name = "user_id")
+	@JoinColumn(name = "user_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
 	private List<BookmarkEntity> bookmarks = new ArrayList<>();
 
 	// For Spring Security==============================================================================================
@@ -86,6 +96,18 @@ public class UserEntity extends BaseEntity {
 		this.userStatus = userStatus;
 		this.provider = provider;
 		this.providerId = providerId;
+	}
+
+	public static UserEntity createByOAuthUser(OAuth2UserPrincipal oAuthUser) {
+		return UserEntity.builder()
+			.username(oAuthUser.getUsername())
+			.nickname(RandomNicknameGenerator.setRandomNickname())
+			.email(oAuthUser.getEmail())
+			.role(Role.ROLE_USER)
+			.userStatus(UserStatus.USER_STATUS_CREATED)
+			.provider(oAuthUser.getProvider())
+			.providerId(oAuthUser.getProviderId())
+			.build();
 	}
 
 	public void setUserInitialInfo(UserRequestDto.UserUpdateRequest userUpdateRequest) {
@@ -113,17 +135,5 @@ public class UserEntity extends BaseEntity {
 		this.username = oAuthUser.getUsername();
 		this.provider = oAuthUser.getProvider();
 		this.providerId = oAuthUser.getProviderId();
-	}
-
-	public static UserEntity createByOAuthUser(OAuth2UserPrincipal oAuthUser) {
-		return UserEntity.builder()
-			.username(oAuthUser.getUsername())
-			.nickname(RandomNicknameGenerator.setRandomNickname())
-			.email(oAuthUser.getEmail())
-			.role(Role.ROLE_USER)
-			.userStatus(UserStatus.USER_STATUS_CREATED)
-			.provider(oAuthUser.getProvider())
-			.providerId(oAuthUser.getProviderId())
-			.build();
 	}
 }

--- a/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -64,7 +65,7 @@ public class UserEntity extends BaseEntity {
 	private String providerId;
 
 	@OneToMany
-	private List<BookmarkEntity> bookmarks;
+	private List<BookmarkEntity> bookmarks = new ArrayList<>();
 
 	// For Spring Security==============================================================================================
 	@Builder

--- a/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/echall/platform/user/domain/entity/UserEntity.java
@@ -1,6 +1,9 @@
 package com.echall.platform.user.domain.entity;
 
+import static com.echall.platform.message.error.code.BookmarkErrorCode.*;
+
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
+import com.echall.platform.message.error.exception.CommonException;
 import com.echall.platform.oauth2.domain.info.OAuth2UserPrincipal;
 import com.echall.platform.user.domain.dto.UserRequestDto;
 import com.echall.platform.user.domain.enums.Gender;
@@ -65,6 +68,7 @@ public class UserEntity extends BaseEntity {
 	private String providerId;
 
 	@OneToMany
+	@JoinColumn(name = "user_id")
 	private List<BookmarkEntity> bookmarks = new ArrayList<>();
 
 	// For Spring Security==============================================================================================

--- a/src/main/java/com/echall/platform/user/repository/UserRepository.java
+++ b/src/main/java/com/echall/platform/user/repository/UserRepository.java
@@ -1,14 +1,16 @@
 package com.echall.platform.user.repository;
 
-import com.echall.platform.user.domain.entity.UserEntity;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
+import com.echall.platform.user.domain.entity.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
 	Optional<UserEntity> findByEmail(String email);
+
 	@Query("SELECT u FROM UserEntity u JOIN FETCH u.bookmarks WHERE u.id = :id")
-	public UserEntity findUserWithBookmarks(Long id);
+	Optional<UserEntity> findUserWithBookmarks(Long id);
 }

--- a/src/main/java/com/echall/platform/user/repository/UserRepository.java
+++ b/src/main/java/com/echall/platform/user/repository/UserRepository.java
@@ -2,10 +2,13 @@ package com.echall.platform.user.repository;
 
 import com.echall.platform.user.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
 	Optional<UserEntity> findByEmail(String email);
+	@Query("SELECT u FROM UserEntity u JOIN FETCH u.bookmarks WHERE u.id = :id")
+	public UserEntity findUserWithBookmarks(Long id);
 }


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
1. [[REFACTOR] 북마크 리팩토링 및 일부 기능 추가](https://github.com/Kernel360/F2-ENGLISH-CHALLENGING-BE/pull/104/commits/e6f9ddfd253c611cc614d7b2152bc9f29645a43b)
- 북마크 request, response 리팩토링
- 북마크 엔티티에 description 추가
    - put 요청으로 description 변경 가능
- 북마크 post, put 분리
2. [[FEAT] 컨텐츠 POST, PUT 분리 및 조회 수 기능 추가](https://github.com/Kernel360/F2-ENGLISH-CHALLENGING-BE/pull/104/commits/621694b14939a893b5a005753465ba6d7de8851b)
- **POST, PUT 분리 아님, 일부 리팩토링 및 기능 추가 임** 
- 컨텐츠 미리보기 id 리턴 하도록 추가
- content 엔티티에 hit 컬럼 추가 (0으로 초기값)
- 게시글 상세 조회 작동 시 hit 업데이트
- sortBy, num 은 초기값을 hits, 8로 주었지만 다른 값으로 요청 가능
    - 다만 아직 sortBy 조건이 여러 개인 경우는 고려하지 않음
    - queryDsl 활용해서 존재하는 컬럼인지 확인
    - 예외 처리 [[FEAT] 컨텐츠 미리보기 조회 시 정렬 조건 에러 추가](https://github.com/Kernel360/F2-ENGLISH-CHALLENGING-BE/pull/104/commits/19f7a99261b0f8f7ffa82e2019170e1d6e1f973d)
3. [[REFACTOR] 북마크 삭제 기능 분리 및 user bookmark 매핑 수정](https://github.com/Kernel360/F2-ENGLISH-CHALLENGING-BE/pull/104/commits/519ddfb4b7f0f28f81acb6dc833bb3de2285a10a)
- 북마크 삭제 기능 업데이트에서 분리
- 유저 북마크 매핑 단방향이고 추가 테이블 생성하지 않도록 매핑 수정

### 참고 사항
- 관련 이슈 번호: #103 
- 노션에 응답/에러 코드 업데이트 완료


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [x] 관련 문서를 업데이트했는지 확인
