### PR TITLE
[FEAT] 북마크 전체 조회 기능 추가

### DIFF
--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -2,10 +2,11 @@ package com.echall.platform.bookmark.controller;
 
 import static com.echall.platform.message.response.BookmarkResponseCode.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,13 +45,12 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
-	public ResponseEntity<ApiCustomResponse<List<BookmarkResponseDto.BookmarkMyListResponse>>> getBookmarks(
-		Authentication authentication,
-		@PathVariable Long contentId
-	) {
-		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_VIEW_SUCCESS, bookmarkService.getBookmarks(authentication.getName(), contentId)
-		);
+	public ResponseEntity<ApiCustomResponse<Map<String, List<BookmarkResponseDto.BookmarkListResponseDto>>>>
+	getBookmarks(@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal, @PathVariable Long contentId) {
+		Map<String, List<BookmarkResponseDto.BookmarkListResponseDto>> data = new HashMap<>();
+		data.put("bookmarkList", bookmarkService.getBookmarks(oAuth2UserPrincipal.getEmail(), contentId));
+
+		return ResponseEntityFactory.toResponseEntity(BOOKMARK_VIEW_SUCCESS, data);
 	}
 
 	@GetMapping("/view")
@@ -60,14 +60,13 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
-	public ResponseEntity<ApiCustomResponse<List<BookmarkResponseDto.BookmarkMyListResponse>>> getAllBookmarks(
-		@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal
-		) {
-		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_VIEW_SUCCESS, bookmarkService.getAllBookmarks(oAuth2UserPrincipal.getId())
-		);
-	}
+	public ResponseEntity<ApiCustomResponse<Map<String, List<BookmarkResponseDto.BookmarkMyListResponseDto>>>>
+	getAllBookmarks(@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal) {
+		Map<String, List<BookmarkResponseDto.BookmarkMyListResponseDto>> data = new HashMap<>();
+		data.put("bookmarkList", bookmarkService.getAllBookmarks(oAuth2UserPrincipal.getId()));
 
+		return ResponseEntityFactory.toResponseEntity(BOOKMARK_VIEW_SUCCESS, data);
+	}
 
 	@PostMapping("/create/{contentId}")
 	@Operation(summary = "북마크 생성", description = "회원이 북마크를 생성합니다.")
@@ -77,14 +76,14 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
 	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkCreateResponse>> createBookmark(
-		Authentication authentication,
+		@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal,
 		@PathVariable Long contentId,
 		@RequestBody BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto
 	) {
 
 		return ResponseEntityFactory.toResponseEntity(
 			BOOKMARK_CREATE_SUCCESS,
-			bookmarkService.createBookmark(authentication.getName(), bookmarkRequestDto, contentId)
+			bookmarkService.createBookmark(oAuth2UserPrincipal.getEmail(), bookmarkRequestDto, contentId)
 		);
 	}
 
@@ -95,7 +94,7 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
-	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkMyListResponse>> updateBookmark(
+	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkListResponseDto>> updateBookmark(
 		@PathVariable Long contentId,
 		@RequestBody BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto
 	) {
@@ -112,14 +111,12 @@ public class BookmarkApiController {
 		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
 		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
 	})
-	public ResponseEntity<ApiCustomResponse<BookmarkResponseDto.BookmarkDeleteResponse>> deleteBookmark(
+	public ResponseEntity<ApiCustomResponse> deleteBookmark(
 		@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal,
 		@PathVariable Long bookmarkId
 	) {
-
-		return ResponseEntityFactory.toResponseEntity(
-			BOOKMARK_DELETE_SUCCESS, bookmarkService.deleteBookmark(oAuth2UserPrincipal.getId(), bookmarkId)
-		);
+		bookmarkService.deleteBookmark(oAuth2UserPrincipal.getId(), bookmarkId);
+		return ResponseEntityFactory.toResponseEntity(BOOKMARK_DELETE_SUCCESS);
 	}
 
 }

--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -63,7 +63,7 @@ public class BookmarkApiController {
 	public ResponseEntity<ApiCustomResponse<Map<String, List<BookmarkResponseDto.BookmarkMyListResponseDto>>>>
 	getAllBookmarks(@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal) {
 		Map<String, List<BookmarkResponseDto.BookmarkMyListResponseDto>> data = new HashMap<>();
-		data.put("bookmarkList", bookmarkService.getAllBookmarks(oAuth2UserPrincipal.getId()));
+		data.put("bookmarkMyList", bookmarkService.getAllBookmarks(oAuth2UserPrincipal.getId()));
 
 		return ResponseEntityFactory.toResponseEntity(BOOKMARK_VIEW_SUCCESS, data);
 	}

--- a/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
+++ b/src/main/java/com/echall/platform/bookmark/controller/BookmarkApiController.java
@@ -53,6 +53,22 @@ public class BookmarkApiController {
 		);
 	}
 
+	@GetMapping("/view")
+	@Operation(summary = "북마크 전체 조회", description = "회원이 등록해 둔 모든 북마크 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.", content = @Content),
+		@ApiResponse(responseCode = "204", description = "컨텐츠가 없습니다.", content = @Content),
+		@ApiResponse(responseCode = "500", description = "서버 에러가 발생하였습니다.", content = @Content)
+	})
+	public ResponseEntity<ApiCustomResponse<List<BookmarkResponseDto.BookmarkMyListResponse>>> getAllBookmarks(
+		@AuthenticationPrincipal OAuth2UserPrincipal oAuth2UserPrincipal
+		) {
+		return ResponseEntityFactory.toResponseEntity(
+			BOOKMARK_VIEW_SUCCESS, bookmarkService.getAllBookmarks(oAuth2UserPrincipal.getId())
+		);
+	}
+
+
 	@PostMapping("/create/{contentId}")
 	@Operation(summary = "북마크 생성", description = "회원이 북마크를 생성합니다.")
 	@ApiResponses(value = {

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkRequestDto.java
@@ -12,11 +12,7 @@ public class BookmarkRequestDto {
 		Long wordIndex,
 		String description
 	) {
-		public void validate() {
-			if (wordIndex == null) {
-				throw new CommonException(BOOKMARK_NEED_ANY_INDEX);
-			}
-		}
+
 	}
 
 	public record BookmarkUpdateRequest(

--- a/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/dto/BookmarkResponseDto.java
@@ -1,16 +1,19 @@
 package com.echall.platform.bookmark.domain.dto;
 
+import java.time.LocalDateTime;
+
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
+import com.echall.platform.content.domain.entity.ContentEntity;
 
 public class BookmarkResponseDto {
-	public record BookmarkMyListResponse(
+	public record BookmarkListResponseDto(
 		Long bookmarkId,
 		Long sentenceIndex,
 		Long wordIndex,
 		String description
 	) {
-		public static BookmarkMyListResponse of(BookmarkEntity bookmark) {
-			return new BookmarkMyListResponse(
+		public static BookmarkListResponseDto of(BookmarkEntity bookmark) {
+			return new BookmarkListResponseDto(
 				bookmark.getId(),
 				bookmark.getSentenceIndex(),
 				bookmark.getWordIndex(),
@@ -19,24 +22,46 @@ public class BookmarkResponseDto {
 		}
 	}
 
+	public record BookmarkMyListResponseDto(
+		Long bookmarkId,
+		String bookmarkDetail,
+		String description,
+		Long contentId,
+		String contentTitle,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt
+	) {
+		public static BookmarkMyListResponseDto of(
+			BookmarkEntity bookmark, String title
+		) {
+			return new BookmarkMyListResponseDto(
+				bookmark.getId(),
+				bookmark.getDetail(),
+				bookmark.getDescription(),
+				bookmark.getScriptIndex(),
+				title,
+				bookmark.getCreatedAt(),
+				bookmark.getUpdatedAt()
+			);
+		}
+	}
+
 	public record BookmarkCreateResponse(
 		Long bookmarkId,
 		Long scriptIndex,
 		Long sentenceIndex,
-		Long wordIndex
+		Long wordIndex,
+		String description
 	) {
 		public static BookmarkCreateResponse of(BookmarkEntity bookmark) {
 			return new BookmarkCreateResponse(
 				bookmark.getId(),
 				bookmark.getScriptIndex(),
 				bookmark.getSentenceIndex(),
-				bookmark.getWordIndex()
+				bookmark.getWordIndex(),
+				bookmark.getDescription()
 			);
 		}
-	}
-	public record BookmarkDeleteResponse(
-		Long bookmarkId
-	){
 	}
 
 }

--- a/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
+++ b/src/main/java/com/echall/platform/bookmark/domain/entity/BookmarkEntity.java
@@ -37,15 +37,19 @@ public class BookmarkEntity extends BaseEntity {
 	private Long wordIndex;
 
 	@Column(columnDefinition = "varchar(255)")
+	private String detail;
+
+	@Column(columnDefinition = "varchar(255)")
 	private String description;
 
 	@Builder
 	public BookmarkEntity(
-		@NotNull Long scriptIndex, Long sentenceIndex, Long wordIndex, String description
+		@NotNull Long scriptIndex, Long sentenceIndex, Long wordIndex, String detail, String description
 	) {
 		this.scriptIndex = scriptIndex;
 		this.sentenceIndex = sentenceIndex;
 		this.wordIndex = wordIndex;
+		this.detail = detail;
 		this.description = description;
 	}
 

--- a/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
@@ -1,5 +1,7 @@
 package com.echall.platform.bookmark.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;

--- a/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/BookmarkRepository.java
@@ -1,7 +1,5 @@
 package com.echall.platform.bookmark.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;

--- a/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
@@ -6,4 +6,5 @@ import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 
 public interface BookmarkRepositoryCustom {
 	Long deleteBookmark(Long userId, Long bookmarkId);
+	List<BookmarkEntity> getAllBookmarks(Long userId);
 }

--- a/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.echall.platform.bookmark.repository.custom;
 
 import java.util.List;
 
+import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 
 public interface BookmarkRepositoryCustom {

--- a/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/repository/custom/BookmarkRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.echall.platform.bookmark.domain.entity.QBookmarkEntity.*;
 import static com.echall.platform.message.error.code.BookmarkErrorCode.*;
 import static com.echall.platform.user.domain.entity.QUserEntity.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
@@ -32,5 +33,14 @@ public class BookmarkRepositoryImpl extends QuerydslRepositorySupport implements
 			.execute();
 
 		return bookmark.getId();
+	}
+
+	@Override
+	public List<BookmarkEntity> getAllBookmarks(Long userId) {
+		return from(userEntity)
+			.join(userEntity.bookmarks, bookmarkEntity)
+			.select(bookmarkEntity)
+			.where(userEntity.id.eq(userId))
+			.fetch();
 	}
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
@@ -6,11 +6,11 @@ import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 
 public interface BookmarkService {
-	List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String email, Long contentId);
+	List<BookmarkResponseDto.BookmarkListResponseDto> getBookmarks(String email, Long contentId);
 
-	List<BookmarkResponseDto.BookmarkMyListResponse> getAllBookmarks(Long userId);
+	List<BookmarkResponseDto.BookmarkMyListResponseDto> getAllBookmarks(Long userId);
 
-	BookmarkResponseDto.BookmarkMyListResponse updateBookmark(
+	BookmarkResponseDto.BookmarkListResponseDto updateBookmark(
 		BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
 	);
 
@@ -18,5 +18,5 @@ public interface BookmarkService {
 		String email, BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, Long contentId
 	);
 
-	BookmarkResponseDto.BookmarkDeleteResponse deleteBookmark(Long userId, Long bookmarkId);
+	void deleteBookmark(Long userId, Long bookmarkId);
 }

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkService.java
@@ -8,6 +8,8 @@ import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 public interface BookmarkService {
 	List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String email, Long contentId);
 
+	List<BookmarkResponseDto.BookmarkMyListResponse> getAllBookmarks(Long userId);
+
 	BookmarkResponseDto.BookmarkMyListResponse updateBookmark(
 		BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
 	);

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -50,6 +50,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<BookmarkResponseDto.BookmarkMyListResponseDto> getAllBookmarks(Long userId) {
 		List<BookmarkEntity> bookmarks = bookmarkRepository.getAllBookmarks(userId);
 

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -43,6 +43,14 @@ public class BookmarkServiceImpl implements BookmarkService {
 	}
 
 	@Override
+	public List<BookmarkResponseDto.BookmarkMyListResponse> getAllBookmarks(Long userId) {
+		return bookmarkRepository.getAllBookmarks(userId)
+			.stream()
+			.map(BookmarkResponseDto.BookmarkMyListResponse::of)
+			.toList();
+	}
+
+	@Override
 	@Transactional
 	public BookmarkResponseDto.BookmarkCreateResponse createBookmark(
 		String email, BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, Long contentId

--- a/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
+++ b/src/main/java/com/echall/platform/bookmark/service/BookmarkServiceImpl.java
@@ -1,10 +1,12 @@
 package com.echall.platform.bookmark.service;
 
 import static com.echall.platform.message.error.code.BookmarkErrorCode.*;
+import static com.echall.platform.message.error.code.ContentErrorCode.*;
 import static com.echall.platform.message.error.code.UserErrorCode.*;
 
 import java.util.List;
 
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,9 @@ import com.echall.platform.bookmark.domain.dto.BookmarkRequestDto;
 import com.echall.platform.bookmark.domain.dto.BookmarkResponseDto;
 import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 import com.echall.platform.bookmark.repository.BookmarkRepository;
+import com.echall.platform.content.domain.entity.ContentDocument;
+import com.echall.platform.content.repository.ContentRepository;
+import com.echall.platform.content.repository.ContentScriptRepository;
 import com.echall.platform.message.error.exception.CommonException;
 import com.echall.platform.user.domain.entity.UserEntity;
 import com.echall.platform.user.repository.UserRepository;
@@ -23,10 +28,12 @@ import lombok.RequiredArgsConstructor;
 public class BookmarkServiceImpl implements BookmarkService {
 	private final UserRepository userRepository;
 	private final BookmarkRepository bookmarkRepository;
+	private final ContentRepository contentRepository;
+	private final ContentScriptRepository contentScriptRepository;
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<BookmarkResponseDto.BookmarkMyListResponse> getBookmarks(String email, Long contentId) {
+	public List<BookmarkResponseDto.BookmarkListResponseDto> getBookmarks(String email, Long contentId) {
 		UserEntity user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new CommonException(USER_NOT_FOUND));
 		List<BookmarkEntity> bookmarks = user.getBookmarks()
@@ -38,16 +45,18 @@ public class BookmarkServiceImpl implements BookmarkService {
 		}
 
 		return bookmarks.stream()
-			.map(BookmarkResponseDto.BookmarkMyListResponse::of)
+			.map(BookmarkResponseDto.BookmarkListResponseDto::of)
 			.toList();
 	}
 
 	@Override
-	public List<BookmarkResponseDto.BookmarkMyListResponse> getAllBookmarks(Long userId) {
-		return bookmarkRepository.getAllBookmarks(userId)
-			.stream()
-			.map(BookmarkResponseDto.BookmarkMyListResponse::of)
-			.toList();
+	public List<BookmarkResponseDto.BookmarkMyListResponseDto> getAllBookmarks(Long userId) {
+		List<BookmarkEntity> bookmarks = bookmarkRepository.getAllBookmarks(userId);
+
+		return bookmarks.stream()
+			.map(bookmark -> BookmarkResponseDto.BookmarkMyListResponseDto.of(
+				bookmark, contentRepository.findTitleById(bookmark.getScriptIndex())
+			)).toList();
 	}
 
 	@Override
@@ -55,10 +64,12 @@ public class BookmarkServiceImpl implements BookmarkService {
 	public BookmarkResponseDto.BookmarkCreateResponse createBookmark(
 		String email, BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, Long contentId
 	) {
-		bookmarkRequestDto.validate();
 
 		UserEntity user = userRepository.findByEmail(email)
 			.orElseThrow(() -> new CommonException(USER_NOT_FOUND));
+		ContentDocument content = contentScriptRepository.findContentDocumentById(
+			new ObjectId(contentRepository.findMongoIdByContentId(contentId))
+		).orElseThrow(() -> new CommonException(CONTENT_NOT_FOUND));
 
 		if (bookmarkRepository.existsByScriptIndexAndScriptIndexAndWordIndex(
 			contentId, bookmarkRequestDto.sentenceIndex(), bookmarkRequestDto.wordIndex()
@@ -71,6 +82,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 			.sentenceIndex(bookmarkRequestDto.sentenceIndex())
 			.wordIndex(bookmarkRequestDto.wordIndex())
 			.description(bookmarkRequestDto.description())
+			.detail(extractDetail(bookmarkRequestDto, content))
 			.build();
 
 		bookmarkRepository.save(bookmark);
@@ -81,7 +93,7 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 	@Override
 	@Transactional
-	public BookmarkResponseDto.BookmarkMyListResponse updateBookmark(
+	public BookmarkResponseDto.BookmarkListResponseDto updateBookmark(
 		BookmarkRequestDto.BookmarkUpdateRequest bookmarkRequestDto, Long contentId
 	) {
 
@@ -90,13 +102,27 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 		bookmark.updateDescription(bookmarkRequestDto);
 
-		return BookmarkResponseDto.BookmarkMyListResponse.of(bookmark);
+		return BookmarkResponseDto.BookmarkListResponseDto.of(bookmark);
 	}
 
 	@Override
 	@Transactional
-	public BookmarkResponseDto.BookmarkDeleteResponse deleteBookmark(Long userId, Long bookmarkId) {
+	public void deleteBookmark(Long userId, Long bookmarkId) {
+		bookmarkRepository.deleteBookmark(userId, bookmarkId);
+	}
 
-		return new BookmarkResponseDto.BookmarkDeleteResponse(bookmarkRepository.deleteBookmark(userId, bookmarkId));
+	// Internal Methods ------------------------------------------------------------------------------------------------
+	private String extractDetail(
+		BookmarkRequestDto.BookmarkCreateRequest bookmarkRequestDto, ContentDocument content
+	) {
+		return truncate(bookmarkRequestDto.wordIndex() == null ?
+				content.getScripts().get(Math.toIntExact(bookmarkRequestDto.sentenceIndex())).getEnScript() :
+				content.getScripts().get(Math.toIntExact(bookmarkRequestDto.sentenceIndex())).getEnScript()
+					.split(" ")[Math.toIntExact(bookmarkRequestDto.wordIndex())],
+			255);
+	}
+
+	private String truncate(String content, int maxLength) {
+		return content.length() > maxLength ? content.substring(0, maxLength) : content;
 	}
 }

--- a/src/main/java/com/echall/platform/content/repository/ContentRepository.java
+++ b/src/main/java/com/echall/platform/content/repository/ContentRepository.java
@@ -1,7 +1,5 @@
 package com.echall.platform.content.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.echall.platform.content.domain.entity.ContentEntity;

--- a/src/main/java/com/echall/platform/content/repository/ContentRepository.java
+++ b/src/main/java/com/echall/platform/content/repository/ContentRepository.java
@@ -1,8 +1,12 @@
 package com.echall.platform.content.repository;
 
-import com.echall.platform.content.domain.entity.ContentEntity;
-import com.echall.platform.content.repository.custom.ContentRepositoryCustom;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.echall.platform.content.domain.entity.ContentEntity;
+import com.echall.platform.content.repository.custom.ContentRepositoryCustom;
+
 public interface ContentRepository extends JpaRepository<ContentEntity, Long>, ContentRepositoryCustom {
+
 }

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
@@ -23,7 +23,7 @@ public interface ContentRepositoryCustom {
 
 	Page<ContentEntity> findAllByContentTypeAndCategory(ContentType contentType, Pageable pageable, Long categoryId);
 
-	String findTitleById(Long contentIds);
+	String findTitleById(Long contentId);
 
 	String findMongoIdByContentId(Long contentId);
 }

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryCustom.java
@@ -22,4 +22,8 @@ public interface ContentRepositoryCustom {
 	int updateHit(Long contentId);
 
 	Page<ContentEntity> findAllByContentTypeAndCategory(ContentType contentType, Pageable pageable, Long categoryId);
+
+	String findTitleById(Long contentIds);
+
+	String findMongoIdByContentId(Long contentId);
 }

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
@@ -171,11 +171,11 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 	}
 
 	@Override
-	public String findTitleById(Long contentIds) {
+	public String findTitleById(Long contentId) {
 
 		return from(contentEntity)
 			.select(contentEntity.title)
-			.where(contentEntity.id.in(contentIds))
+			.where(contentEntity.id.eq(contentId))
 			.fetchFirst();
 	}
 

--- a/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
+++ b/src/main/java/com/echall/platform/content/repository/custom/ContentRepositoryImpl.java
@@ -1,5 +1,23 @@
 package com.echall.platform.content.repository.custom;
 
+import static com.echall.platform.content.domain.entity.QContentEntity.*;
+import static com.echall.platform.message.error.code.ContentErrorCode.*;
+import static com.echall.platform.message.error.code.UserErrorCode.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.echall.platform.content.domain.dto.ContentResponseDto;
 import com.echall.platform.content.domain.entity.ContentDocument;
 import com.echall.platform.content.domain.entity.ContentEntity;
@@ -13,24 +31,6 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQuery;
-import org.bson.types.ObjectId;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
-import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static com.echall.platform.content.domain.entity.QContentEntity.contentEntity;
-import static com.echall.platform.message.error.code.ContentErrorCode.CONTENT_NOT_FOUND;
-import static com.echall.platform.message.error.code.ContentErrorCode.CONTENT_SORT_COL_NOT_FOUND;
-import static com.echall.platform.message.error.code.UserErrorCode.USER_NOT_FOUND;
 
 public class ContentRepositoryImpl extends QuerydslRepositorySupport implements ContentRepositoryCustom {
 
@@ -151,7 +151,8 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 	}
 
 	@Override
-	public Page<ContentEntity> findAllByContentTypeAndCategory(ContentType contentType, Pageable pageable, Long categoryId) {
+	public Page<ContentEntity> findAllByContentTypeAndCategory(ContentType contentType, Pageable pageable,
+		Long categoryId) {
 		JPQLQuery<ContentEntity> query = from(contentEntity)
 			.select(contentEntity)
 			.where(contentEntity.contentType.eq(contentType)
@@ -167,6 +168,23 @@ public class ContentRepositoryImpl extends QuerydslRepositorySupport implements 
 				.and(categoryId != null ? contentEntity.category.id.eq(categoryId) : null));
 
 		return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchOne);
+	}
+
+	@Override
+	public String findTitleById(Long contentIds) {
+
+		return from(contentEntity)
+			.select(contentEntity.title)
+			.where(contentEntity.id.in(contentIds))
+			.fetchFirst();
+	}
+
+	@Override
+	public String findMongoIdByContentId(Long contentId) {
+		return from(contentEntity)
+			.select(contentEntity.mongoContentId)
+			.where(contentEntity.id.eq(contentId))
+			.fetchOne();
 	}
 
 }

--- a/src/main/java/com/echall/platform/message/error/code/BookmarkErrorCode.java
+++ b/src/main/java/com/echall/platform/message/error/code/BookmarkErrorCode.java
@@ -17,10 +17,6 @@ public enum BookmarkErrorCode implements ErrorCode {
 	),
 	BOOKMARK_ALREADY_EXISTS(
 		HttpStatus.BAD_REQUEST, BookmarkServiceStatus.BOOKMARK_ALREADY_EXISTS, "이미 존재하는 북마크입니다."
-	),
-	BOOKMARK_NEED_ANY_INDEX(
-		HttpStatus.BAD_REQUEST, BookmarkServiceStatus.BOOKMARK_NEED_ANY_INDEX,
-		"단어 북마크를 지정하려면 문장 혹은 단어 인덱스가 필요합니다."
 	);
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
+++ b/src/main/java/com/echall/platform/message/status/BookmarkServiceStatus.java
@@ -13,8 +13,7 @@ public enum BookmarkServiceStatus implements ServiceStatus {
 	// failure,
 	BOOKMARK_NOT_FOUND("U-B-901"),
 	BOOKMARK_DESCRIPTION_SAME("U-B-902"),
-	BOOKMARK_ALREADY_EXISTS("U-B-903"),
-	BOOKMARK_NEED_ANY_INDEX("U-B-904")
+	BOOKMARK_ALREADY_EXISTS("U-B-903")
 	;
 
 	private final String code;

--- a/src/main/java/com/echall/platform/user/repository/UserRepository.java
+++ b/src/main/java/com/echall/platform/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.echall.platform.user.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/echall/platform/user/repository/UserRepository.java
+++ b/src/main/java/com/echall/platform/user/repository/UserRepository.java
@@ -1,12 +1,9 @@
 package com.echall.platform.user.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import com.echall.platform.bookmark.domain.entity.BookmarkEntity;
 import com.echall.platform.user.domain.entity.UserEntity;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 북마크 전체 조회 기능 추가
- [[REFACTORING] 북마크 전체 조회 기능 수정](https://github.com/Kernel360/F2-ENGLISH-CHALLENGING-BE/pull/159/commits/10fc83df761fae7f464c2ff45d781429d6e1633e)
    - 북마크 전체 조회 시 북마크한 컨텐츠 제목, 북마크 내용, 시간 등의 리턴 값 요청사항 반영
    - 북마크 조회 시 mysql, mongo 두 db 를 모두 조회하는 것이 부담되어서 북마크 생성 시에 북마크 한 내용도 저장하는 방향으로 수정함 
        - 사이즈는 255로 제한
    - 수정되지 않았던 Map 리턴이나 OAuth2UserPrincipal 수정
    - 북마크 생성 시 word 가 null 인 경우를 예외 처리 하여 문장 북마크 생성을 막던 것 수정


### 참고 사항
- 관련 이슈 번호: #157 
- 기타 참고해야 할 사항이나 리뷰어가 알아야 할 내용을 작성해주세요.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [x] 관련 문서를 업데이트했는지 확인
