### PR TITLE
[REFACTOR] OAUTH2 로그인 리다이렉트 URL 동적으로 추가하는 로직 개발

### DIFF
--- a/src/main/java/com/echall/platform/config/SecurityConfig.java
+++ b/src/main/java/com/echall/platform/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.echall.platform.config;
 import com.echall.platform.oauth2.OAuth2FailureHandler;
 import com.echall.platform.oauth2.OAuth2SuccessHandler;
 import com.echall.platform.oauth2.TokenProvider;
+import com.echall.platform.oauth2.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import com.echall.platform.oauth2.service.OAuth2UserCustomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,6 +39,7 @@ public class SecurityConfig {
 	private final OAuth2SuccessHandler oAuth2SuccessHandler;
 	private final OAuth2FailureHandler oAuth2FailureHandler;
 	private final AccessDeniedHandler accessDeniedHandler;
+	private final OAuth2AuthorizationRequestBasedOnCookieRepository oAuth2AuthorizationRequestBasedOnCookieRepository;
 
 	@Value("${spring.profiles.active}")
 	private String activeProfile;
@@ -101,6 +103,9 @@ public class SecurityConfig {
 		http
 			.oauth2Login(oauth2 -> oauth2
 				.loginPage("/login")
+				.authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint
+					.authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository)
+				)
 				.userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint
 					.userService(oAuth2UserCustomService)
 				)

--- a/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -1,56 +1,59 @@
-// TODO: 추후에도 필요가 없어지면 삭제
+package com.echall.platform.oauth2.repository;
 
-//package com.echall.platform.oauth2.repository;
-//
-//import java.util.Objects;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-//import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
-//import org.springframework.stereotype.Component;
-//import org.springframework.web.util.WebUtils;
-//
-//import com.echall.platform.util.CookieUtil;
-//
-//import jakarta.servlet.http.Cookie;
-//import jakarta.servlet.http.HttpServletRequest;
-//import jakarta.servlet.http.HttpServletResponse;
-//
-//@Component
-//@RequiredArgsConstructor
-//public class OAuth2AuthorizationRequestBasedOnCookieRepository
-//	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
-//	public final static String OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_authorization_request";
-//	public final static int COOKIE_EXPIRE_SECONDS = 18000;
-//	private final CookieUtil cookieUtil;
-//
-//	@Override
-//	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-//		Cookie cookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE);
-//		if(cookie == null) {
-//			return null;
-//		}
-//		return cookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class);
-//	}
-//
-//	@Override
-//	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
-//		HttpServletResponse response) {
-//		if(authorizationRequest == null) {
-//			removeAuthorizationRequest(request,response);
-//			return;
-//		}
-//		cookieUtil.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE,
-//			cookieUtil.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
-//	}
-//
-//	@Override
-//	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
-//		HttpServletResponse response) {
-//		return this.loadAuthorizationRequest(request);
-//	}
-//
-//	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
-//		cookieUtil.removeCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE);
-//	}
-//}
+import com.echall.platform.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthorizationRequestBasedOnCookieRepository
+	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+	private final CookieUtil cookieUtil;
+
+	private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_authorization_request";
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+
+		Cookie cookie = WebUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE);
+		if(cookie == null) {
+			return null;
+		}
+
+		return cookieUtil.deserialize(cookie, OAuth2AuthorizationRequest.class);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+		HttpServletResponse response) {
+
+		if(authorizationRequest == null) {
+			removeAuthorizationRequest(request,response);
+			return;
+		}
+
+		cookieUtil.addOAuth2AuthorizationRequestCookie(request, response, authorizationRequest);
+
+		cookieUtil.addReturnUrlCookie(request, response);
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+		HttpServletResponse response) {
+
+		return this.loadAuthorizationRequest(request);
+	}
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+
+		cookieUtil.removeOAuth2AuthorizationRequestCookie(request, response);
+
+		cookieUtil.removeReturnUrlCookie(request, response);
+	}
+}

--- a/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
+++ b/src/main/java/com/echall/platform/oauth2/repository/OAuth2AuthorizationRequestBasedOnCookieRepository.java
@@ -34,7 +34,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository
 		HttpServletResponse response) {
 
 		if(authorizationRequest == null) {
-			removeAuthorizationRequest(request,response);
+			removeCookies(request,response);
 			return;
 		}
 
@@ -50,7 +50,7 @@ public class OAuth2AuthorizationRequestBasedOnCookieRepository
 		return this.loadAuthorizationRequest(request);
 	}
 
-	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+	public void removeCookies(HttpServletRequest request, HttpServletResponse response) {
 
 		cookieUtil.removeOAuth2AuthorizationRequestCookie(request, response);
 

--- a/src/main/java/com/echall/platform/util/CookieUtil.java
+++ b/src/main/java/com/echall/platform/util/CookieUtil.java
@@ -23,7 +23,7 @@ public class CookieUtil {
 	public static final String REFRESH_TOKEN_NAME = "refresh_token";
 	public static final String OAUTH2_AUTHORIZATION_REQUEST_NAME = "oauth2_authorization_request";
 	public static final String RETURN_URL_NAME = "return_url";
-	public static final String RETURN_URL_REQUEST_PARAMETER_NAME = "returnUrl";
+	public static final String RETURN_URL_REQUEST_PARAMETER = "returnUrl";
 	public static final Duration ACCESS_TOKEN_COOKIE_EXPIRE = Duration.ofDays(1);
 	public static final Duration REFRESH_TOKEN_COOKIE_EXPIRE = Duration.ofDays(7);
 	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofSeconds(10);
@@ -55,7 +55,7 @@ public class CookieUtil {
 
 	public void addReturnUrlCookie(HttpServletRequest request, HttpServletResponse response) {
 		removeCookie(request, response, RETURN_URL_NAME);
-		addCookie(response, RETURN_URL_NAME, request.getParameter(RETURN_URL_REQUEST_PARAMETER_NAME),
+		addCookie(response, RETURN_URL_NAME, request.getParameter(RETURN_URL_REQUEST_PARAMETER),
 			(int) RETURN_URL_NAME_COOKIE_EXPIRE.toSeconds());
 	}
 

--- a/src/main/java/com/echall/platform/util/CookieUtil.java
+++ b/src/main/java/com/echall/platform/util/CookieUtil.java
@@ -1,22 +1,33 @@
 package com.echall.platform.util;
 
-import java.time.Duration;
-import java.util.Arrays;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
-import org.springframework.stereotype.Component;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.SerializationUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+
 
 @Component
 public class CookieUtil {
 	public static final String ACCESS_TOKEN_NAME = "access_token";
 	public static final String REFRESH_TOKEN_NAME = "refresh_token";
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_NAME = "oauth2_authorization_request";
+	public static final String RETURN_URL_NAME = "return_url";
+	public static final String RETURN_URL_REQUEST_PARAMETER_NAME = "returnUrl";
 	public static final Duration ACCESS_TOKEN_COOKIE_EXPIRE = Duration.ofDays(1);
 	public static final Duration REFRESH_TOKEN_COOKIE_EXPIRE = Duration.ofDays(7);
+	public static final Duration OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE = Duration.ofSeconds(10);
+	public static final Duration RETURN_URL_NAME_COOKIE_EXPIRE = Duration.ofSeconds(10);
 
 	@Value("${spring.profiles.active}")
 	private String activeProfile;
@@ -27,12 +38,25 @@ public class CookieUtil {
 
 	public void addAccessTokenCookie(HttpServletRequest request, HttpServletResponse response, String accessToken) {
 		removeCookie(request, response, ACCESS_TOKEN_NAME);
-		addCookie(response, ACCESS_TOKEN_NAME, accessToken, (int)ACCESS_TOKEN_COOKIE_EXPIRE.toSeconds());
+		addCookie(response, ACCESS_TOKEN_NAME, accessToken, (int) ACCESS_TOKEN_COOKIE_EXPIRE.toSeconds());
 	}
 
 	public void addRefreshTokenCookie(HttpServletRequest request, HttpServletResponse response, String refreshToken) {
 		removeCookie(request, response, REFRESH_TOKEN_NAME);
-		addCookie(response, REFRESH_TOKEN_NAME, refreshToken, (int)REFRESH_TOKEN_COOKIE_EXPIRE.toSeconds());
+		addCookie(response, REFRESH_TOKEN_NAME, refreshToken, (int) REFRESH_TOKEN_COOKIE_EXPIRE.toSeconds());
+	}
+
+	public void addOAuth2AuthorizationRequestCookie(HttpServletRequest request, HttpServletResponse response,
+													OAuth2AuthorizationRequest oAuth2AuthorizationRequest) {
+		removeCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_NAME);
+		addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_NAME, serialize(oAuth2AuthorizationRequest),
+			(int) OAUTH2_AUTHORIZATION_REQUEST_COOKIE_EXPIRE.toSeconds());
+	}
+
+	public void addReturnUrlCookie(HttpServletRequest request, HttpServletResponse response) {
+		removeCookie(request, response, RETURN_URL_NAME);
+		addCookie(response, RETURN_URL_NAME, request.getParameter(RETURN_URL_REQUEST_PARAMETER_NAME),
+			(int) RETURN_URL_NAME_COOKIE_EXPIRE.toSeconds());
 	}
 
 	public void removeAccessTokenCookie(HttpServletRequest request, HttpServletResponse response) {
@@ -43,7 +67,15 @@ public class CookieUtil {
 		removeCookie(request, response, REFRESH_TOKEN_NAME);
 	}
 
-	// Internal Methods=================================================================================================
+	public void removeOAuth2AuthorizationRequestCookie(HttpServletRequest request, HttpServletResponse response) {
+		removeCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_NAME);
+	}
+
+	public void removeReturnUrlCookie(HttpServletRequest request, HttpServletResponse response) {
+		removeCookie(request, response, RETURN_URL_NAME);
+	}
+
+    // Internal Methods=================================================================================================
 	// TODO: https 연결하고 검토 필요
 	private void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
 		String cookieValue = createCookieValue(name, value, maxAge);
@@ -64,23 +96,22 @@ public class CookieUtil {
 		}
 	}
 
-	// TODO: 추후에도 필요가 없어지면 삭제
-	//	public String serialize(Object obj) {
-	//		return Base64.getUrlEncoder()
-	//			.encodeToString(SerializationUtils.serialize(obj));
-	//	}
-	//
-	//	public <T> T deserialize(Cookie cookie, Class<T> cls) {
-	//		byte[] decodedBytes = Base64.getUrlDecoder().decode(cookie.getValue());
-	//
-	//		try (
-	//			 ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(decodedBytes))
-	//		) {
-	//			return cls.cast(objectInputStream.readObject());
-	//		} catch (IOException | ClassNotFoundException e) {
-	//			throw new IllegalArgumentException("Failed to deserialize object", e);
-	//		}
-	//	}
+	public String serialize(Object obj) {
+		return Base64.getUrlEncoder()
+			.encodeToString(SerializationUtils.serialize(obj));
+	}
+
+	public <T> T deserialize(Cookie cookie, Class<T> cls) {
+		byte[] decodedBytes = Base64.getUrlDecoder().decode(cookie.getValue());
+
+		try (
+			 ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(decodedBytes))
+		) {
+			return cls.cast(objectInputStream.readObject());
+		} catch (IOException | ClassNotFoundException e) {
+			throw new IllegalArgumentException("Failed to deserialize object", e);
+		}
+	}
 
 	private String createCookieValue(String name, String value, int maxAge) {
 		ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(name, value)


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 테스트 코드 추가
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 개발 환경 세팅

### 변경 사항
- 기존에 있었지만 사용안하던 OAuth2AuthorizationRequestBasedOnCookieRepository 사용
- 추가로 프론트에서 보낸 returnUrl을 받아 쿠키에 저장하여 OAuth2SuccessHandler에서 사용하는 방식으로 구현


### 참고 사항
- 관련 이슈 번호: #215 
- 원래 이인제 디렉터님 말씀처럼 URL로만 returnUrl을 들고 있다가 OAuth2SuccessHandler에서 가져오는 방식을 하려고 했지만, 그렇게 구현하기엔 시간이 많이 소요될 수도 있고, 가능하다고 100% 확신할 수가 없어서 쿠키 방식을 사용했습니다. (디렉터님 말씀을 제가 잘못 이해한 거일 수도 있지만요.)
- OAuth2AuthorizationRequestBasedOnCookieRepository 와 OAuth2SuccessHandler 에 쿠키를 받아오는 메서드가 있는데, 이것을 CookieUtil에 둘지 말지 의견을 주시면 감사하겠습니다.


### 셀프 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [ ] 새로운 테스트를 추가했거나 기존 테스트를 통과하는지 확인
- [x] 코드 스타일 가이드에 맞게 포맷팅했는지 확인
- [ ] 관련 문서를 업데이트했는지 확인
